### PR TITLE
Add Dockerfile and .dockerignore for building docker containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+*.env
+.env*
+
+*~*
+*#*
+.DS_Store
+
+/assets
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:buster
+
+WORKDIR /root/koinos-miner
+
+RUN apt-get update -qy && \
+    apt-get install -qy git cmake build-essential libssl-dev && \
+    apt-get clean -qy
+
+COPY . /root/koinos-miner
+
+RUN npm install --unsafe-perm
+
+ENV privateKey
+
+ENTRYPOINT [ "npm", "start", "--" ]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . /root/koinos-miner
 
 RUN npm install --unsafe-perm
 
-ENV privateKey
+#ENV privateKey
 
 ENTRYPOINT [ "npm", "start", "--" ]
 


### PR DESCRIPTION
Added Dockerfile and .dockerignore for building docker containers

NOTE: We've linked our fork to DockerHub with automated DockerHub image building + publishing at https://hub.docker.com/repository/docker/privex/koinos-miner - so you can deploy it with:

```
docker run --env-file /root/koinos-miner/.env --rm -itd privex/koinos-miner -a 0x27AE12ea4723C755AfbB604289507516613cd37c --use-env
```

Let us know if you make any important updates and we'll happily merge them into our fork 👍 